### PR TITLE
Fix the openio_galera_master_node default value jinja formula

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,8 @@ openio_galera_root_password: root
 
 
 openio_galera_bind_interface: eth0
-openio_galera_master_node: "{{ groups[openio_galera_nodes_group][0] |
-  map('extract', hostvars, ['ansible_' ~ openio_galera_bind_interface, 'ipv4', 'address']) }}"
+openio_galera_master_node: "{{ hostvars[groups[openio_galera_nodes_group][0]]
+  ['ansible_' ~ openio_galera_bind_interface]['ipv4']['address'] }}"
 openio_galera_wsrep_cluster_address: "gcomm://{{ groups[openio_galera_nodes_group] |
   map('extract', hostvars, ['ansible_' ~ openio_galera_bind_interface, 'ipv4', 'address']) | join(',') }}"
 openio_galera_bind_address: "{{ hostvars[inventory_hostname]['ansible_' +


### PR DESCRIPTION
openio_galera_master_node is defined as the following:

"{{ groups[openio_galera_nodes_group][0] | map('extract', hostvars, ['ansible_' ~ openio_galera_bind_interface, 'ipv4', 'address']) }}"

which is wrong, as `groups[openio_galera_nodes_group]` is a list of strings,
so `groups[openio_galera_nodes_group][0]` is a string that we pipe through
map('extract', ...)

The following task

- debug:
    var: openio_galera_master_node

was displaying:

TASK [openio-galera : debug] *******************************************
ok: [mars2] => {
    "openio_galera_master_node": "<generator object do_map at 0x7f4421c81aa0>"
}

which is the *string* "<generator object do_map @>" and not the
generator object itself.

This was making the test, line 74 of tasks/main.yml always fail:

    - openio_galera_bind_address == openio_galera_master_node

Thanks to @cdelgehier for the help