### PR TITLE
increase number of retries when waiting for mariaDB to start

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     enabled: true
   register: mysql_started
   until: mysql_started is success
-  retries: 2
+  retries: 5
   delay: 10
   tags: configure
 


### PR DESCRIPTION
Changing from 2 to 5 because 2 could, sometimes, be two low and cause
the task to fail whereas mariadb would have started several seconds
later