### PR TITLE
BUGFIX/MINOR(galera): Fix wrong conditional expression in `Retry starting service for securing`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,8 +78,7 @@
   delay: 10
   tags: configure
   failed_when:
-    - _openio_galera_service_started2.state is not defined
-    - _openio_galera_service_started2.state != 'started'
+    - _openio_galera_service_started2 is failed or _openio_galera_service_started2.state != 'started'
   when: _openio_galera_service_started.state is not defined or _openio_galera_service_started.state != 'started'
   ignore_errors: "{{ ansible_check_mode }}"
 


### PR DESCRIPTION

 ##### SUMMARY

When MariaDB can't start, the role fails on a jinja expression.
Now, the role retries and fails normally
 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Before
```console
TASK [galera : Retry starting service for securing] ***********************************************
Tuesday 26 March 2019  16:22:27 +0000 (0:00:00.074)       0:00:04.263 *********
skipping: [node2]
skipping: [node4]
fatal: [node3]: FAILED! =>
  msg: 'The conditional check ''_openio_galera_service_started2.state != ''started'''' failed. The error was: error while evaluating conditional (_openio_galera_service_started2.state != ''started''): ''dict object'' has no attribute ''state'''
```
After
```console
TASK [galera : Retry starting service for securing] ***********************************************
Wednesday 27 March 2019  09:51:35 +0000 (0:00:00.077)       0:00:04.303 *******
skipping: [node2]
skipping: [node4]
FAILED - RETRYING: Retry starting service for securing (2 retries left).
FAILED - RETRYING: Retry starting service for securing (1 retries left).
fatal: [node3]: FAILED! => changed=false
  attempts: 2
  failed_when_result: true
  msg: |-
    Unable to start service mariadb: Job for mariadb.service failed because the control process exited with error code. See "systemctl status mariadb.service" and "journalctl -xe" for details.
```