### PR TITLE
BUGFIX/MINOR(galera): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,10 +3,12 @@
   apt_key:
     keyserver: keyserver.ubuntu.com
     id: "{{ openio_galera_repo_gpgkey }}"
+  tags: install
 
 - name: repository installation
   apt_repository:
     filename: "{{ openio_galera_repo_filename }}"
     repo: "{{ openio_galera_repo_baseurl }}"
     update_cache: true
+  tags: install
 ...

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -7,7 +7,7 @@
     login_unix_socket: "{{ openio_galera_socket }}"
   when: not _openio_galera_mysqld_already_running.stdout or _openio_galera_wsrep_on.stderr is defined
   register: "_openio_galera_wsrep_on"
-  tags: install
+  tags: configure
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure service is stopped
@@ -20,10 +20,12 @@
     or (_openio_galera_systemctl_set_environment is defined and not _openio_galera_systemctl_set_environment.skipped)
     or (_openio_galera_wsrep_cluster_size.stdout|int == 0)
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Remove systemctl MYSQLD_OPTS environment option
   command: systemctl unset-environment MYSQLD_OPTS
   when: _openio_galera_systemctl_set_environment.cmd is defined
+  tags: configure
 
 - name: Start the master node
   command: "{{ openio_galera_bin_new_cluster }}"
@@ -41,6 +43,7 @@
     - openio_galera_bind_address == openio_galera_master_node
     - ansible_service_mgr == 'systemd'
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Create SST user
   mysql_user:
@@ -63,6 +66,7 @@
         or (_openio_galera_wsrep_cluster_size.stdout|int == 0)
     - openio_galera_bind_address == openio_galera_master_node
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Start the slave nodes
   service:
@@ -81,4 +85,5 @@
         or (_openio_galera_wsrep_cluster_size.stdout|int == 0)
     - openio_galera_bind_address != openio_galera_master_node
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -19,12 +21,13 @@
   changed_when: false
   ignore_errors: true
   register: _openio_galera_mysqld_already_running
+  tags: configure
 
 - name: Check data directory
   stat:
     path: "{{ openio_galera_datadir }}"
   register: "_openio_galera_data_exist"
-  tags: install
+  tags: configure
 
 - name: Check Galera cluster wsrep status
   mysql_variables:
@@ -34,7 +37,7 @@
     login_unix_socket: "{{ openio_galera_socket }}"
   when: _openio_galera_mysqld_already_running.stdout
   register: "_openio_galera_wsrep_on"
-  tags: install
+  tags: configure
   failed_when: false
   ignore_errors: "{{ ansible_check_mode }}"
 
@@ -66,6 +69,7 @@
   command: systemctl set-environment MYSQLD_OPTS="--wsrep_on=OFF"
   when: _openio_galera_service_started.state is not defined or _openio_galera_service_started.state != 'started'
   register: _openio_galera_systemctl_set_environment
+  tags: configure
 
 - name: Retry starting service for securing
   service:
@@ -87,7 +91,7 @@
     mysql -BN -u root -p"{{ openio_galera_root_password }}" -e "SHOW GLOBAL STATUS LIKE 'wsrep_cluster_size'"|cut -f2
   changed_when: false
   register: "_openio_galera_wsrep_cluster_size"
-  tags: install
+  tags: configure
   when: "(_openio_galera_wsrep_on.msg is defined and _openio_galera_wsrep_on.msg == 'ON') \
           or _openio_galera_service_started is success"
   ignore_errors: "{{ ansible_check_mode }}"
@@ -115,6 +119,7 @@
     value: "{{ openio_galera_swappiness }}"
     state: present
   when: ansible_virtualization_type != 'docker'
+  tags: install
 
 - name: Bootstrap Cluster
   import_tasks: bootstrap.yml
@@ -140,6 +145,7 @@
       delay: 5
       until: _galera_check is success
       changed_when: false
+      tags: configure
       when:
         - not openio_galera_provision_only
   when: openio_bootstrap | d(false)

--- a/tasks/postinstall.yml
+++ b/tasks/postinstall.yml
@@ -9,6 +9,7 @@
   with_items: "{{ openio_galera_databases }}"
   register: _db
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Copy database init scripts
   copy:
@@ -19,6 +20,7 @@
   when:
     - item.changed
     - item.item.init_script is defined
+  tags: configure
 
 - name: Initialise databases
   mysql_db:
@@ -32,6 +34,7 @@
   when:
     - item.changed
     - item.item.init_script is defined
+  tags: configure
 
 - name: Delete init scripts from the server
   file:
@@ -41,6 +44,7 @@
   when:
     - item.changed
     - item.item.init_script is defined
+  tags: configure
 
 - name: Create the users
   mysql_user:
@@ -55,4 +59,5 @@
     login_unix_socket: "{{ openio_galera_socket }}"
   with_items: "{{ openio_galera_users }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 ...

--- a/tasks/secure_install.yml
+++ b/tasks/secure_install.yml
@@ -4,12 +4,14 @@
   register: _check_password
   changed_when: false
   failed_when: false
+  tags: configure
 
 - name: Set the MySQL root password
   command: 'mysqladmin -u root password "{{ openio_galera_root_password }}"'
   changed_when: false
   when: _check_password.rc == 0
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Delete anonymous connections
   mysql_user:
@@ -19,6 +21,7 @@
     state: absent
     login_unix_socket: "{{ openio_galera_socket }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: "Secure the MySQL root user for localhost"
   mysql_user:
@@ -33,6 +36,7 @@
     - "localhost"
     #- "{{ openio_galera_bind_address }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 
 - name: Remove the MySQL test database
   mysql_db:
@@ -42,4 +46,5 @@
     state: absent
     login_unix_socket: "{{ openio_galera_socket }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION