### PR TITLE
BUGFIX/MINOR(galera): Fixed red output from a task

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -28,6 +28,7 @@
   when: _openio_galera_systemctl_set_environment.cmd is not defined
   ignore_errors: true
   changed_when: false
+  failed_when: false
   tags: configure
 
 - name: Remove systemctl MYSQLD_OPTS environment option


### PR DESCRIPTION
 ##### SUMMARY
The task "Check for wsrep in systemctl MYSQLD_OPTS environment option"
can show a red output on an error which is ignored.
Adding the option failed_when: false hide it from the user.

 ##### IMPACT
N/A