### PR TITLE
BUGFIX/MINOR(galera): Add compat with python3

### DIFF
--- a/templates/galera.cnf.j2
+++ b/templates/galera.cnf.j2
@@ -12,7 +12,7 @@ wsrep_max_ws_size={{ openio_galera_wsrep_max_ws_size }}
 wsrep_sst_method={{ openio_galera_wsrep_sst_method }}
 wsrep_certify_nonPK={{ openio_galera_wsrep_certify_nonPK }}
 wsrep_sst_auth={{ openio_galera_sst_user }}:{{ openio_galera_sst_password }}
-{% for k, v in openio_galera_extra_parameters.iteritems() %}
+{% for k, v in openio_galera_extra_parameters.items() | list %}
 {{ k }}={{ v }}
 {% endfor %}
 {% if openio_galera_replication %}


### PR DESCRIPTION
 ##### SUMMARY

Replace python 2 syntax by one compatible with python 2 and 3.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
failed: [node01] (item={'src': 'galera.cnf.j2', 'dest': '/etc/my.cnf.d/galera.cnf'}) => changed=false
  ansible_loop_var: item
  item:
    dest: /etc/my.cnf.d/galera.cnf
    src: galera.cnf.j2
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''iteritems'''
failed: [node15] (item={'src': 'galera.cnf.j2', 'dest': '/etc/my.cnf.d/galera.cnf'}) => changed=false
  ansible_loop_var: item
  item:
    dest: /etc/my.cnf.d/galera.cnf
    src: galera.cnf.j2
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''iteritems'''
```
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems