### PR TITLE
CHANGE(galera): allow to disable sysctl management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ openio_galera_databases:
 
 openio_galera_extra_parameters: {}
 
+openio_galera_sysctl_managed: true
 openio_galera_swappiness: 0
 openio_galera_wsrep_sst_method: xtrabackup-v2
 openio_galera_binlog_format: "ROW"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,7 +118,9 @@
     name: vm.swappiness
     value: "{{ openio_galera_swappiness }}"
     state: present
-  when: ansible_virtualization_type != 'docker'
+  when:
+    - openio_galera_sysctl_managed
+    - ansible_virtualization_type != 'docker'
   tags: install
 
 - name: Bootstrap Cluster


### PR DESCRIPTION
 ##### SUMMARY

by setting `openio_galera_sysctl_managed` to `false` the role
won't set any sysctl variable

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION