### PR TITLE
TRIVIAL(galera): cast swappiness variable to int to prevent warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,7 +116,7 @@
 - name: Configure swappiness
   sysctl:
     name: vm.swappiness
-    value: "{{ openio_galera_swappiness }}"
+    value: "{{ openio_galera_swappiness | int }}"
     state: present
   when:
     - openio_galera_sysctl_managed


### PR DESCRIPTION
 ##### SUMMARY

The `openio_galera_swappiness` variable was not cast to int,
thereforce ansible was throwing a warning

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION